### PR TITLE
Removed unsupported payment methods

### DIFF
--- a/_posts/2018/02/2018-02-22-policy.md
+++ b/_posts/2018/02/2018-02-22-policy.md
@@ -156,13 +156,7 @@ You can use USD, EUR, GBP, or JPY (format like `17EUR` or `25.50GBP`), but all p
 <a id="20" href="#20">§20</a>
 "Wallet."
 We can send you money either via
-[PayPal](https://www.paypal.com),
-[Bitcoin](https://bitcoin.org/en/),
-[Bitcoin Cash](https://www.bitcoincash.org/),
-[Ethereum](https://www.ethereum.org/),
-[Litecoin](https://litecoin.org/)
-or
-[Zold](https://wts.zold.io).
+[PayPal](https://www.paypal.com) or [Zold](https://wts.zold.io).
 To tell us how exactly you want to receive them just say `wallet` to Zerocrat.
 
 <a id="46" href="#46">§46</a>


### PR DESCRIPTION
zerocracy/farm#1920 - removed "Bitcoin", "Litecoin", "Ethereum", "Bitcoin cash" payment methods.