### PR TITLE
Renamed wallet to payouts

### DIFF
--- a/_posts/2018/02/2018-02-22-policy.md
+++ b/_posts/2018/02/2018-02-22-policy.md
@@ -156,9 +156,9 @@ You can use USD, EUR, GBP, or JPY (format like `17EUR` or `25.50GBP`), but all p
 (converted by [apilayer](https://apilayer.net)).
 
 <a id="20" href="#20">§20</a>
-"Wallet."
-We can send you money via [Zold](https://wts.zold.io).
-To tell us how exactly you want to receive them just say `wallet` to Zerocrat.
+"Payouts."
+We send all payouts in [Zold](https://zold.io),
+you can find them in [WTS](https://wts.zold.io) if you login there with your GitHub ID.
 
 <a id="46" href="#46">§46</a>
 "Debt."


### PR DESCRIPTION
zerocracy/farm#1860 - renamed wallet section to "payouts", updated the text