### PR TITLE
Describe `continue` command in the Policy

### DIFF
--- a/_posts/2018/02/2018-02-22-policy.md
+++ b/_posts/2018/02/2018-02-22-policy.md
@@ -136,8 +136,8 @@ The ARC makes a subjective non-disputable decision whether a reported bug deserv
 <a id="9" href="#9">§9</a>
 "Impediments."
 You may declare impediments for a job by saying `wait` to Zerocrat.
-While the job has impediments [Ten Days rule](#8)
-is not applicable to it.
+While the job has impediments, the [Ten Days rule](#8) is not applicable to it.
+Note, however, that the `ARC` may bring the job out of "waiting" status at any time (see [§57](#57)).
 
 <a id="36" href="#36">§36</a>
 "Speed Bonus."
@@ -373,6 +373,10 @@ QA role can't overlap with REV, DEV or ARC.
 "Scope In/Out."
 You should add jobs to the scope, by saying `in` to Zerocrat (or assigning the ticket to him).
 You can remove a job from the scope by saying `out`.
+
+<a id="57" href="#57">§57</a>
+"Continue."
+You can "wake" jobs out of `waiting` status (see [§9](#9)) by saying `continue` to Zerocrat.
 
 <a id="53" href="#53">§53</a>
 "Auto-In."


### PR DESCRIPTION
The `continue` command is missing from the policy.