### PR TITLE
Rephrased bad issue quality

### DIFF
--- a/_posts/2018/02/2018-02-22-policy.md
+++ b/_posts/2018/02/2018-02-22-policy.md
@@ -487,8 +487,8 @@ The quality of a job is "bad" if any of the following happens
 (these violations we can't forgive):
 
   * The code reviewer didn't find any issues in the source code
-    changes of a pull request and just accepted it;
-  * The job is closed without a solution provided.
+    changes of a pull request and just accepted it.
+  * The performer didn't provide any solution to close the job.
 
 <a id="31" href="#31">§31</a>
 "QA Bonus."


### PR DESCRIPTION
#96 - explicitly say that issue quality is bad if **performer** didn't provide a solution to avoid misunderstanding.